### PR TITLE
Possibility to override the default options to the call of plugin

### DIFF
--- a/assets/js/confirm-bootstrap.js
+++ b/assets/js/confirm-bootstrap.js
@@ -19,7 +19,7 @@
 
 
  (function($) {
-    $.fn.confirmModal = function()
+    $.fn.confirmModal = function(opts)
     {
         $('body').append('<div id="confirmContainer"></div>');
         var confirmContainer = $('#confirmContainer');
@@ -39,7 +39,7 @@
                 confirmDirection : 'rtl'
             };
 
-            var options = $.extend(defaults, targetData);
+            var options = $.extend(defaults, opts, targetData);
 
             var modal =
             '<div class="modal" id="confirmModal">' +


### PR DESCRIPTION
Exemple :

``` javascript
$('.delete-confirm').confirmModal({
  confirmTitle     : 'Custom please confirm',
  confirmMessage   : 'Custom are you sure you want to perform this action ?',
  confirmOk        : 'Custom yes',
  confirmCancel    : 'Cutom cancel'
});
```
